### PR TITLE
Some updates for TestCircuitORAMRec{,Server,Client}

### DIFF
--- a/test/oram/TestCircuitOramRec.java
+++ b/test/oram/TestCircuitOramRec.java
@@ -167,7 +167,7 @@ public class TestCircuitOramRec {
 					Flag.sw.startTotal();
 					server.write(server.baseOram.lib.toSignals(element), scData);
 					 Flag.sw.stopTotal();
-					 Flag.sw.addCounter();
+					 if(i != 0) Flag.sw.addCounter();
 //					printStatistic();
 				}
 

--- a/test/oram/TestCircuitOramRec.java
+++ b/test/oram/TestCircuitOramRec.java
@@ -115,8 +115,8 @@ public class TestCircuitOramRec {
 
 					// Assert.assertTrue(Utils.toInt(b) == element);
 //					if (Utils.toInt(b) != element)
-						System.out.println("inconsistent: " + element + " "
-								+ Utils.toInt(b));
+//						System.out.println("inconsistent: " + element + " "
+//								+ Utils.toInt(b));
 				}
 
 				os.flush();

--- a/test/oram/TestCircuitOramRec.java
+++ b/test/oram/TestCircuitOramRec.java
@@ -100,7 +100,7 @@ public class TestCircuitOramRec {
 					double t = Flag.sw.stopTotal();
 //					System.out.println(Flag.sw.ands + " " + t / 1000000000.0
 //							+ " " + Flag.sw.ands / t * 1000);
-					Flag.sw.addCounter();
+					if(i != 0) Flag.sw.addCounter();
 
 //					Runtime rt = Runtime.getRuntime();
 //					double usedMB = (rt.totalMemory() - rt.freeMemory()) / 1024.0 / 1024.0;

--- a/test/oram/TestCircuitOramRecClient.java
+++ b/test/oram/TestCircuitOramRecClient.java
@@ -1,17 +1,20 @@
 package oram;
 
+import java.util.concurrent.TimeUnit;
 import oram.TestCircuitOramRec.EvaRunnable;
 import flexsc.Flag;
 
 public class TestCircuitOramRecClient {
 
 	public  static void main(String args[]) throws Exception {
-		for(int i = 8; i <=24 ; i+=4) {
+		for(int i = 12; i <=20 ; i+=2) {
 			Flag.sw.flush();
 			EvaRunnable eva = new EvaRunnable("localhost", 12345);
 			eva.run();
 			Flag.sw.print();
 			System.out.print("\n");
+			
+			TimeUnit.SECONDS.sleep(1);
 		}
 	}
 }

--- a/test/oram/TestCircuitOramRecServer.java
+++ b/test/oram/TestCircuitOramRecServer.java
@@ -12,7 +12,6 @@ public class TestCircuitOramRecServer {
 			gen.run();
 			Flag.sw.print();
 			System.out.print("\n");
-			//asdasdasdas
 		}
 	}
 }


### PR DESCRIPTION
This PR consists of the following changes:

- remove the false alarm of inconsistency in TestCircuitOramRec.java, which is now commented.
- add 1s delay for RecClient after one experiment. for remote testing (my experiment environment has 20ms latency), RecClient starts too early that RecServer is not prepared, and TLS reset.
- remove the strange comment in RecServer.